### PR TITLE
Data-driven frontpage widgets

### DIFF
--- a/_data/widgets.yml
+++ b/_data/widgets.yml
@@ -1,0 +1,31 @@
+- title: "Blog & Portfolio"
+  link: /blog/
+  image: /images/widget-1-302x182.jpg
+  blurb_markdown: |
+    Every good portfolio website has a blog with fresh news, thoughts and develop&shy;ments of your activities.
+
+    _Feeling Responsive_ offers you a fully functional blog with an archive page to give readers a quick overview of all your posts.
+  has_video: false
+  video_path:
+- title: "Why use this theme?"
+  link: /info/
+  image: /images/start-video-feeling-responsive-302x182.jpg
+  blurb_markdown: |
+    _Feeling Responsive_ has great features:
+
+    1. Multilingual support.
+    1. Mobile-friendly responsive design.
+    1. Foolproof SEO built right in.
+    1. Built on [Foundation Framework](http://foundation.zurb.com/).
+    1. Seven different header treatments.
+    1. Configurable footer content.
+    1. Optimised for editing in [CloudCannon](http://cloudcannon.com/).
+  has_video: true
+  video_path: https://www.youtube.com/embed/3b5zCFSmVvU
+- title: "Download Theme"
+  link: https://github.com/Phlow/feeling-responsive-v2
+  image: /images/widget-github-303x182.jpg
+  blurb_markdown: |
+    _Feeling Responsive_ is free and open source under the MIT license. Make it your own and start building. Grab the [Barebones Version](https://github.com/Phlow/feeling-responsive/tree/bare-bones-version) for a fresh start. Or learn how to use it with the [Educational Version](https://github.com/Phlow/feeling-responsive/tree/gh-pages) with sample posts and images. Then tell me via Twitter [@phlow](http://twitter.com/phlow).
+  has_video: false
+  video_path:

--- a/_includes/helper/social_media_icons.html
+++ b/_includes/helper/social_media_icons.html
@@ -13,19 +13,19 @@
 #
 {% endcomment %}
 {% if site.socialmedia.github %}
-  <li class="social-media-icon"><a href="https://github.com/{{ site.socialmedia.github }}" target="_blank" title="{{ site.data.language.follow_me_on }} Github">{% include svg-social-media/github_ring.svg %}</a></li>
+  <li class="social-media-icon"><a href="https://github.com/{{ site.socialmedia.github }}" target="_blank" title="{{ site.data.ui[site.lang].follow_me_on }} Github">{% include svg-social-media/github_ring.svg %}</a></li>
 {% endif %}
 
 {% if site.socialmedia.youtube %}
-  <li class="social-media-icon"><a href="https://www.youtube.com/user/{{ site.socialmedia.youtube }}" target="_blank" title="{{ site.data.language.follow_me_on }} Youtube">{% include svg-social-media/youtube.svg %}</a></li>
+  <li class="social-media-icon"><a href="https://www.youtube.com/user/{{ site.socialmedia.youtube }}" target="_blank" title="{{ site.data.ui[site.lang].follow_me_on }} Youtube">{% include svg-social-media/youtube.svg %}</a></li>
 {% endif %}
 
 {% if site.socialmedia.twitter %}
-  <li class="social-media-icon"><a href="https://twitter.com/{{ site.socialmedia.twitter }}" target="_blank" title="{{ site.data.language.follow_me_on }} Twitter">{% include svg-social-media/twitter.svg %}</a></li>
+  <li class="social-media-icon"><a href="https://twitter.com/{{ site.socialmedia.twitter }}" target="_blank" title="{{ site.data.ui[site.lang].follow_me_on }} Twitter">{% include svg-social-media/twitter.svg %}</a></li>
 {% endif %}
 
 {% if site.socialmedia.facebook %}
-  <li class="social-media-icon"><a href="https://facebook.com/{{ site.socialmedia.facebook }}" target="_blank" title="{{ site.data.language.follow_me_on }} Facebook">{% include svg-social-media/facebook_square.svg %}</a></li>
+  <li class="social-media-icon"><a href="https://facebook.com/{{ site.socialmedia.facebook }}" target="_blank" title="{{ site.data.ui[site.lang].follow_me_on }} Facebook">{% include svg-social-media/facebook_square.svg %}</a></li>
 {% endif %}
 
 {% if site.socialmedia.soundcloud %}

--- a/_includes/helper/widget.html
+++ b/_includes/helper/widget.html
@@ -1,0 +1,28 @@
+{% assign widget = include.widget %}
+{% assign container_class = include.container_class %}
+
+<div {% if container_class %}class="{{ container_class }}"{% endif %}>
+	{% if widget.has_video %}
+    {% assign modal_id = widget.title | slugify | prepend: "videoModal-" %}
+    <a title="{{ widget.title }}" href="{{ widget.video_path }}" data-reveal-id="{{ modal_id }}">
+      <img src="{% include relative_src src=widget.image %}" width="302" height="182" alt="Click to play video">
+    </a>
+    <div id="{{ modal_id }}" class="reveal-modal large" data-reveal="">
+      <div class="flex-video widescreen vimeo" style="display: block;">
+        <iframe width="1280" height="720" src="{{ widget.video_path }}" frameborder="0" allowfullscreen>
+          <p>Your browser does not support iframes.</p>
+        </iframe>
+      </div>
+      <a class="close-reveal-modal">&#215;</a>
+    </div>
+	{% else %}
+		<a title="{{ widget.title }}" href="{% include relative_src src=widget.link %}">
+			<img src="{% include relative_src src=widget.image %}" alt="{{ widget.title }}">
+		</a>
+	{% endif %}
+	<h2 class="font-size-h3 t10">{{ widget.title }}</h2>
+	{{ widget.blurb_markdown | markdownify }}
+	<p>
+    <a class="button tiny radius" href="{% include relative_src src=widget.link %}">{{ site.data.ui[site.lang].more }}</a>
+  </p>
+</div>

--- a/_includes/relative_src
+++ b/_includes/relative_src
@@ -1,0 +1,1 @@
+{% assign prefix = include.src | slice: 0, 2 %}{% assign protocol = include.src | slice: 0, 4 %}{% unless protocol == 'http' or prefix == "//" %}{{ site.baseurl }}{% endunless %}{{ include.src }}

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -5,33 +5,34 @@ format: frontpage
 <div id="header-home">
     <div class="row">
         <div class="small-12 columns">
-        </div><!-- /.medium-4.columns -->
-    </div><!-- /.row -->
-</div><!-- /#header-home -->
-
+        </div>
+    </div>
+</div>
 
 {% comment %}
 *
 * First check, if widget is empty or not by checking if there is a title
 *
 {% endcomment %}
-<div class="row t60">
-	{% if page.widget1.title %}
-		{% include helper/frontpage-widget.html widget=page.widget1 %}
-	{% endif %}
-
-
-	{% if page.widget2.title %}
-		{% include helper/frontpage-widget.html widget=page.widget2 %}
-	{% endif %}
-
-
-	{% if page.widget3.title %}
-		{% include helper/frontpage-widget.html widget=page.widget3 %}
-	{% endif %}
-</div><!-- /.row -->
-
-
+{% assign widgets = site.data.widgets %}
+{% assign container_class = "medium-4 columns frontpage-widget" %}
+{% if widgets.size > 0 %}
+  {% for widget in widgets %}
+    {% assign loopindex = forloop.index | modulo: 3 %}
+    {% if loopindex == 1 %}
+      <div class="row t60">
+        {% include helper/widget.html widget=widget container_class=container_class %}
+    {% elsif forloop.last %}
+        {% include helper/widget.html widget=widget container_class=container_class %}
+      </div>
+    {% elsif loopindex == 2 %}
+        {% include helper/widget.html widget=widget container_class=container_class %}
+    {% else %}
+        {% include helper/widget.html widget=widget container_class=container_class %}
+      </div>
+    {% endif %}
+  {% endfor %}
+{% endif %}
 
 {% comment %}
 *
@@ -47,11 +48,9 @@ format: frontpage
     <div class="row t60 b60">
         <div class="small-12 text-center columns">
             <a class="button large radius {{ page.callforaction.style }}" href="{{ url }}{{ page.callforaction.url }}"{% if page.callforaction.url contains 'http' %} target="_blank" {% endif %}>{{ page.callforaction.text }}</a>
-        </div><!-- /.small-12.columns -->
-    </div><!-- /.row -->
+        </div>
+    </div>
 {% endif %}
-
-
 
 {% comment %}
 *
@@ -77,9 +76,8 @@ format: frontpage
             <h2>{{ site.data.ui[site.lang].new_blog_entries | default: "New Blog Articles" }}</h2>
             {% endif %}
             {% endfor %}
-        </div><!-- /.small-12.columns -->
-    </div><!-- /.row -->
-
+        </div>
+    </div>
 
     <div class="row">
         <div class="medium-6 columns">
@@ -91,16 +89,14 @@ format: frontpage
                 <a href="{{ post.url | absolute_url }}" title="Read {{ post.title | escape_once }}"><strong>{{ site.data.ui[site.lang].read_more | default: "Read More&nbsp;›" }}</strong></a>
             </p>
             {% endfor %}
-        </div><!-- /.medium-5.columns -->
-
+        </div>
 
         <div class="medium-6 columns">
             <p><strong>{{ site.data.ui[site.lang].more_articles | default: "More Articles" }}</strong></p>
             {% include list-posts entries='3' offset='1' %}
-        </div><!-- /.medium-7.columns -->
-    </div><!-- /.row -->
+        </div>
+    </div>
 {% endunless %}
-
 
 {% comment %}
 *
@@ -110,4 +106,4 @@ format: frontpage
 
 <div class="row">
     {{ content }}
-</div><!-- /.row -->
+</div>

--- a/pages/pages-root-folder/index.md
+++ b/pages/pages-root-folder/index.md
@@ -7,21 +7,6 @@
 layout: frontpage
 header:
   image_fullwidth: header_unsplash_12.jpg
-widget1:
-  title: "Blog & Portfolio"
-  url: 'http://phlow.github.io/feeling-responsive/blog/'
-  image: widget-1-302x182.jpg
-  text: 'Every good portfolio website has a blog with fresh news, thoughts and develop&shy;ments of your activities. <em>Feeling Responsive</em> offers you a fully functional blog with an archive page to give readers a quick overview of all your posts.'
-widget2:
-  title: "Why use this theme?"
-  url: 'http://phlow.github.io/feeling-responsive/info/'
-  text: '<em>Feeling Responsive</em> is heavily customizable.<br/>1. Language-Support :)<br/>2. Optimized for speed and it&#39;s responsive.<br/>3. Built on <a href="http://foundation.zurb.com/">Foundation Framework</a>.<br/>4. Seven different Headers.<br/>5. Customizable navigation, footer,...'
-  video: '<a href="#" data-reveal-id="videoModal"><img src="http://phlow.github.io/feeling-responsive/images/start-video-feeling-responsive-302x182.jpg" width="302" height="182" alt=""/></a>'
-widget3:
-  title: "Download Theme"
-  url: 'https://github.com/Phlow/feeling-responsive'
-  image: widget-github-303x182.jpg
-  text: '<em>Feeling Responsive</em> is free and licensed under a MIT License. Make it your own and start building. Grab the <a href="https://github.com/Phlow/feeling-responsive/tree/bare-bones-version">Bare-Bones-Version</a> for a fresh start or learn how to use it with the <a href="https://github.com/Phlow/feeling-responsive/tree/gh-pages">education-version</a> with sample posts and images. Then tell me via Twitter <a href="http://twitter.com/phlow">@phlow</a>.'
 #
 # Use the call for action to show a button on the frontpage
 #
@@ -43,10 +28,3 @@ permalink: /index.html
 #
 homepage: true
 ---
-
-<div id="videoModal" class="reveal-modal large" data-reveal="">
-  <div class="flex-video widescreen vimeo" style="display: block;">
-    <iframe width="1280" height="720" src="https://www.youtube.com/embed/3b5zCFSmVvU" frameborder="0" allowfullscreen></iframe>
-  </div>
-  <a class="close-reveal-modal">&#215;</a>
-</div>


### PR DESCRIPTION
Rework the homepage widgets in service of #1. High-level this does the following:

- Makes the homepage widgets config-driven
- Allows an unlimited number of widgets
- Uses Markdown instead of HTML for widget formatting
- Introduces the `relative_src` include I pilfered from [frisco-jekyll-template](https://github.com/comfusion/frisco-jekyll-template)
- Enables support for multiple video widgets
- Improves video widget accessibility
- Prevents block-level markup within, or nested paragraphs, where widget blurbs are output
- Updates the Social Icons to use i18n

With these changes users can now add, edit, remove and reorder frontpage widgets front the convenience of the by CloudCannon editor [as described](https://github.com/Phlow/feeling-responsive-v2/pull/6#issuecomment-277286376) in #6 from _Collections_ > _Data_ > _Widgets_. 

![screen shot 2017-02-12 at 5 37 35 pm](https://cloud.githubusercontent.com/assets/440298/22861073/b4d825c4-f14a-11e6-884b-949f0c1b165c.png)
